### PR TITLE
Add tests for Ubuntu on ARM, macOS on Intel, and Windows 2025

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,11 +7,15 @@ on:
 
 jobs:
   tests-linux:
-    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        os: [ubuntu-latest]
         node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
+        include:
+          - os: ubuntu-24.04-arm
+            node-version: 22.x
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -37,11 +41,15 @@ jobs:
       - name: Run tests
         run: npm test
   tests-macos:
-    runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
+        os: [macos-latest]
         node-version: [16.x, 18.x, 20.x, 22.x]
+        include:
+          - os: macos-13
+            node-version: 22.x
+    runs-on: ${{ matrix.os }}
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
     steps:
@@ -52,10 +60,10 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Python 3.10
+      - name: Install Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.10'
+          python-version: 3.13
       - name: Check Node.js version
         run: node -pe process.versions
       - name: Check npm version
@@ -65,11 +73,15 @@ jobs:
       - name: Run tests
         run: npm test
   tests-windows:
-    runs-on: windows-2019
     strategy:
       fail-fast: false
       matrix:
+        os: [windows-2019]
         node-version: [10.x, 12.x, 14.x, 16.x, 18.x, 20.x, 22.x]
+        include:
+          - os: windows-2025
+            node-version: 22.x
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,9 +46,14 @@ jobs:
       matrix:
         os: [macos-latest]
         node-version: [18.x, 20.x, 22.x]
+        python-version: ['3.13']
         include:
+          - os: macos-latest
+            node-version: 16.x
+            python-version: '3.10'
           - os: macos-13
             node-version: 22.x
+            python-version: '3.13'
     runs-on: ${{ matrix.os }}
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -63,7 +68,7 @@ jobs:
       - name: Install Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          python-version: ${{ matrix.python-version }}
       - name: Check Node.js version
         run: node -pe process.versions
       - name: Check npm version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
           - os: macos-latest
             node-version: 16.x
             python-version: '3.10'
-          - os: macos-13
+          - os: macos-15-intel
             node-version: 22.x
             python-version: '3.13'
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,13 +45,10 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest]
-        node-version: [16.x, 18.x, 20.x, 22.x]
+        node-version: [18.x, 20.x, 22.x]
         include:
           - os: macos-13
             node-version: 22.x
-        exclude:  # Fails on Python 3.13.
-          - os: macos-latest
-            node-version: 16.x
     runs-on: ${{ matrix.os }}
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,9 @@ jobs:
         include:
           - os: macos-13
             node-version: 22.x
+        exclude:  # Fails on Python 3.13.
+          - os: macos-latest
+            node-version: 16.x
     runs-on: ${{ matrix.os }}
     env:
       PIP_DISABLE_PIP_VERSION_CHECK: 1
@@ -63,7 +66,7 @@ jobs:
       - name: Install Python 3.13
         uses: actions/setup-python@v5
         with:
-          python-version: 3.13
+          python-version: '3.13'
       - name: Check Node.js version
         run: node -pe process.versions
       - name: Check npm version


### PR DESCRIPTION
On macOS, test on the current version of Python to verify there are no distutils issues.
* nodejs/nan#986

[Standard GitHub-hosted runners for public repositories](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories) --> `ubuntu-24.04-arm`, `macos-13`, and `windows-2025`.
```diff
    strategy:
      matrix:
        include:
+         - os: ubuntu-24.04-arm
+           node-version: 22.x

+         - os: macos-13
+           node-version: 22.x

+         - os: windows-2025
+           node-version: 22.x
```